### PR TITLE
fix: Add new line at the end of a notify_inactive_accounts log

### DIFF
--- a/scripts/notify_inactive_accounts.php
+++ b/scripts/notify_inactive_accounts.php
@@ -58,7 +58,7 @@ foreach ($usernames as $username) {
     if ($count_notified >= 20) {
         // Stop after 20 notified accounts so we don't send too many emails at
         // once.
-        echo 'FreshRSS stopping to notify users after 20 emails.';
+        echo "FreshRSS stopping to notify users after 20 emails.\n";
         break;
     }
 


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Make sure to have more than 20 inactive accounts
2. Run the `scripts/notify_inactive_accounts.php` script
3. Verify that the last log line ends with "FreshRSS stopping to notify users after 20 emails.[new line]"

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
