### PR TITLE
fix: Don't change users' last activity on notification

### DIFF
--- a/scripts/notify_inactive_accounts.php
+++ b/scripts/notify_inactive_accounts.php
@@ -53,6 +53,11 @@ foreach ($usernames as $username) {
     $user_conf->deletion_notified_at = $deletion_notified_at->format('Y-m-d');
     $user_conf->save();
 
+    // This is a bit hacky, but by saving the user conf, we changed the last
+    // activity date. This allows to reset the last activity to its previous
+    // value.
+    touch(USERS_PATH . '/' . $username . '/config.php', $last_activity);
+
     $count_notified += 1;
 
     if ($count_notified >= 20) {


### PR DESCRIPTION
## Related issue(s)

<!-- Copy-paste the URL to the related issue(s) if any ("N/A" if not applicable).
  -->

N/A

## How to test manually

<!-- List actions (step by step) of what have to be done in order to test your
  -- changes manually ("N/A" if not applicable).
  -->

1. Create a user
2. Force its last activity date (ex. `touch -mt 1672527600 data/users/my_user/config.php`)
3. Send the notification email (`php scripts/notify_inactive_accounts.php`)
4. Check in the admin that the last activity didn't change

## Reviewer checklist

<!-- Please don't change or remove this checklist. It will be used by the
  -- reviewer to make sure to not forget important things.
  -- Reviewer: if you think one of the item isn’t applicable to this PR,
  -- please check it anyway.
  -->

- [x] Code is manually tested
- [x] Interface works on both Firefox and Chrome
- [x] Accessibility has been tested
- [x] Copyright notices are up to date
- [x] Documentation is up to date
- [x] Pull request has been reviewed and approved
